### PR TITLE
Removes unneeded CFString: Hashable extension

### DIFF
--- a/Sources/CryptorRSA/CryptorRSAUtilities.swift
+++ b/Sources/CryptorRSA/CryptorRSAUtilities.swift
@@ -366,28 +366,3 @@ extension String {
 		return result
 	}
 }
-
-
-// MARK: -
-
-#if !os(Linux)
-
-	// MARK: -- CFString Extension for Hashing
-	
-	///
-	/// Extension to CFString to make it hashable.
-	///
-	extension CFString: Hashable {
-		
-		/// Return the hash value of a CFString
-		public var hashValue: Int {
-			return (self as String).hashValue
-		}
-		
-		/// Comparison of CFStrings
-		static public func == (lhs: CFString, rhs: CFString) -> Bool {
-			return lhs as String == rhs as String
-		}
-	}
-	
-#endif


### PR DESCRIPTION
Starting with [starting with Swift 4.0](https://github.com/apple/swift/pull/4568) all CF types already conform to Hashable. Therefore this extension is not needed anymore.

## Description
Pre Swift 4.0 this extension was required but since the minimal swift version of this package is 4.0 this part of the code is not needed anymore. The corresponding implementation in the swift stdlib can be found [here](https://github.com/apple/swift/blob/main/stdlib/public/Darwin/CoreFoundation/CoreFoundation.swift).

## Motivation and Context
[Recent](https://github.com/apple/swift/pull/35491) [changes](https://github.com/apple/swift/pull/35061) in the Swift runtime indicate that the order in which protocol conformances are loaded is not guaranteed and might change with swift 5.4 which will ship with the upcoming Xcode release (12.5). 
Therefore the CFString extension of this package might produce unwanted side-effects for the application which is using this package.

## How Has This Been Tested?
Built and run on macOS and iOS. Ran tests on the macOS target.