### PR TITLE
Convert bytes directly to Data instead of UnsafePointer API

### DIFF
--- a/Sources/CryptorRSA/CryptorRSAUtilities.swift
+++ b/Sources/CryptorRSA/CryptorRSAUtilities.swift
@@ -286,7 +286,7 @@ public extension CryptorRSA {
 		index += 1
 		
 		let strippedKeyBytes = [UInt8](byteArray[index...keyData.count - 1])
-		let data = Data(bytes: strippedKeyBytes)
+        let data = Data(strippedKeyBytes)
 		return data
 	}
 	

--- a/Sources/CryptorRSA/CryptorRSAUtilities.swift
+++ b/Sources/CryptorRSA/CryptorRSAUtilities.swift
@@ -286,7 +286,7 @@ public extension CryptorRSA {
 		index += 1
 		
 		let strippedKeyBytes = [UInt8](byteArray[index...keyData.count - 1])
-		let data = Data(bytes: UnsafePointer<UInt8>(strippedKeyBytes), count: keyData.count - index)
+		let data = Data(bytes: strippedKeyBytes)
 		return data
 	}
 	


### PR DESCRIPTION
## Description

Replaces an incorrect use of `UnsafePointer<UInt8>(array)` to initialize `Data`.
There is already a `Data(_ elements: Sequence<UInt8>)` initializer we can use directly.

## Motivation and Context

Using a pointer to an array created via the UnsafePointer initializer is undefined and isn't guaranteed to be valid. In particular, we ran into this issue when our RSA key started failing on iOS 18 release builds. The data in `strippedKeyBytes` was valid on the line above, but `data` was all zeroes after being initialized with `UnsafePointer`.

https://github.com/Kitura/BlueRSA/blob/440f78db26d8bb073f29590f1c7bd31004da09ae/Sources/CryptorRSA/CryptorRSAUtilities.swift#L288-L290

As stated in the "Important" note in the [`UnsafePointer` documentation](https://developer.apple.com/documentation/swift/unsafepointer#Implicit-Casting-and-Bridging):
> The pointer created through implicit bridging of an instance or of an array’s elements is only valid during the execution of the called function. Escaping the pointer to use after the execution of the function is undefined behavior. In particular, do not use implicit bridging when calling an UnsafePointer initializer.

## How Has This Been Tested?

I ran the existing test suite in Release mode. Before the fix there were 16/32 passes, after the fix there are 32/32 passes.

This was tested with Xcode 16.0 (16A242d).
Devices:
- iPhone 13 Pro running iOS 18.0 (22A3354)
- MacBook Pro 14", 2021 running macOS 14.6.1 (23G93)